### PR TITLE
Fix namespace for asm! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // Licensed under the Apache-License 2.0
 
 #![no_std]
-#![feature(asm)]
 
 #[cfg(feature = "rtt")]
 pub mod rtt_logger;
@@ -97,7 +96,7 @@ extern "C" fn do_jump(_sp: u32, _reset: u32) -> ! {
     // r1 = reset
 
     unsafe {
-        asm! {
+        core::arch::asm! {
             // Set the stack-pointer
             "msr msp, r0",
             // Branch to the reset handler.


### PR DESCRIPTION
This commit removes the feature attribute asm and add a namespace for the usage of the asm macro.

Currently the following build error is generated when using rustc 1.66.0-nightly (c0983a9aa 2022-10-12):
```console
$ cargo b
   Compiling drogue-boot v0.1.2 (/iot/drogue/drogue-boot)
error: cannot find macro `asm` in this scope
   --> src/lib.rs:100:9
    |
100 |         asm! {
    |         ^^^
    |
    = note: consider importing this macro:
            core::arch::asm

warning: the feature `asm` has been stable since 1.59.0 and no longer requires an attribute to enable

 --> src/lib.rs:4:12
  |
4 | #![feature(asm)]
  |            ^^^
  |
  = note: `#[warn(stable_features)]` on by default

warning: `drogue-boot` (lib) generated 1 warning
error: could not compile `drogue-boot` due to previous error; 1 warning emitted
```
Refs: https://github.com/rust-lang/rust/issues/84019

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>